### PR TITLE
.asciiのスタイルをマージンからスペースに変更

### DIFF
--- a/preprocessed-site/css/clean-blog.css
+++ b/preprocessed-site/css/clean-blog.css
@@ -417,7 +417,12 @@ body {
   webkit-tap-highlight-color: #0085a1;
 }
 
-.ascii, code {
+code {
   margin-left: 0.25em;
   margin-right: 0.25em;
+}
+
+.ascii:before,
+.ascii:after {
+  content: " ";
 }


### PR DESCRIPTION
aタグの中に日本語と英語が混ざっているとアンダーラインが途切れてしまいます。
前後にスペースをいれて、アンダーラインが途切れないようにしてみました。

### before
![image](https://cloud.githubusercontent.com/assets/1730718/25563467/ac27d13a-2dd7-11e7-9509-0cd3fcd5caa0.png)

### after
![image](https://cloud.githubusercontent.com/assets/1730718/25563476/e58e58ae-2dd7-11e7-8085-a8c7457f34d5.png)

