### PR TITLE
masterブランチにマージしたら、自動でデプロイするための設定の修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,13 @@ deploy: site
 	# Copy the generated site to the temp directory.
 	cp -r generated-site /tmp/haskell-jp-blog-deploy/
 	# Checkout the gh-pages branch.
-	git checkout gh-pages
+ifdef GITHUB_TOKEN
+	git remote set-url origin "https://${GITHUB_TOKEN}@github.com/haskell-jp/blog.git"
+	git fetch origin gh-pages
+	git checkout -b gh-pages FETCH_HEAD
+else
+	git checkout -t origin/gh-pages
+endif
 	# Remove the pages for the current site.
 	git rm -r -f --ignore-unmatch *
 	git status
@@ -67,13 +73,11 @@ deploy: site
 	git status
 	# Do the commit and push.
 	git commit -m "Release $(GIT_HASH) on `date`."
-ifdef GITHUB_TOKEN
-	git push -f "https://${GITHUB_TOKEN}@github.com/haskell-jp/blog.git" gh-pages
-else
 	git push -f origin gh-pages
-endif
 	# Go back to master.
+ifndef GITHUB_TOKEN
 	git checkout master
+endif
 	rm -rf /tmp/haskell-jp-blog-deploy
 
 # Alias for deploy.


### PR DESCRIPTION
https://github.com/haskell-jp/blog/issues/50 の問題への対応である、
https://github.com/haskell-jp/blog/pull/51 において、いろいろ間違いがあったため修正しました。

具体的には、

```
git checkout gh-pages
```

という行や、

```
git checkout master
```

という行において、
gh-pagesブランチ、masterブランチ、ともにTravis CIの環境では明示的に`git fetch`しないと`git checkout`できないようになっているみたいなので、修正しております。

恐らく、

```
git clone --depth=50 --branch=test-deploy
```

と、 `--branch` オプションを使用して`git clone`しているため、masterやgh-pagesブランチが見えていないと思われます。