### PR TITLE
Circle CIへの移行 + build artifactsの設定

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,32 @@
+general:
+  artifacts:
+    - "generated-site/"
+_cache_and_artifacts: &_cache_and_artifacts
+  cache_directories:
+    - "~/.stack/"
+    - ".stack-work/"
+
+dependencies:
+  override:
+    - stack setup
+    - stack install --only-dependencies
+  <<: *_cache_and_artifacts
+
+compile:
+  override:
+    - stack build --pedantic
+    - stack exec -- site build
+    - cp -r generated-site $CIRCLE_ARTIFACTS
+  <<: *_cache_and_artifacts
+
+test:
+  override:
+    - stack test --pedantic
+  <<: *_cache_and_artifacts
+
+deployment:
+  production:
+    branch: master
+    commands:
+      # -e オプションをつけることで、GITHUB_TOKEN環境変数をmakeに渡す
+      make -e deploy


### PR DESCRIPTION
https://github.com/haskell-jp/blog/issues/50 の問題のうち、
「レビュー時に、ビルド(make build)後の記事の見た目を確認するのが面倒」を解決するため、
CIのbuild artifactsからビルドしたブログを閲覧できるよう設定中です。

CircleCIに移行しようとしているのは、[Travis CIのドキュメント曰く](https://docs.travis-ci.com/user/uploading-artifacts/)、Travis CIはAmazon S3にartifactsをアップロードする関係上、
AWSのアカウントを必要とするためです（つまり有料 💸 ）。

ただ、CircleCIはCircleCIで、 https://circleci.com/docs/1.0/build-artifacts/ 曰く、

> Note: This URL is only accessible if you are logged into CircleCI with an account that has permissions to view / edit the project.

とあるとおり、誰でも閲覧できるというわけではないみたいです。
という問題もありますが、とりあえずこれでやってみましょう。