### PR TITLE
コミットメッセージに `[ci skip]` を加えることで、gh-pagesブランチがテストされてしまうのを防ぐ

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ endif
 	git add -A .
 	git status
 	# Do the commit and push.
-	git commit -m "Release $(GIT_HASH) on `date`."
+	git commit -m "Release $(GIT_HASH) on `date` [ci skip]."
 	git push -f origin gh-pages
 	# Go back to master.
 ifndef GITHUB_TOKEN


### PR DESCRIPTION
gh-pagesブランチにはstack.yamlなどのファイルのがないため、gh-pagesブランチがpushされたさいにCIが実行されてしまうと必ずFAILEDになってしまいます。
実害はほぼないですがリソースが無駄だし何より鬱陶しいのでスキップします。

参考: https://discuss.circleci.com/t/cant-ignore-the-gh-pages-branch/2002/2?u=igrep