### PR TITLE
fix link for `type +d`

### DIFF
--- a/preprocessed-site/posts/2017/08-ghc-4way-execution.md
+++ b/preprocessed-site/posts/2017/08-ghc-4way-execution.md
@@ -191,7 +191,7 @@ $ ghc -e ':t foldl'
 foldl :: Foldable t => (b -> a -> b) -> b -> t a -> b
 ```
 
-GHC8.2以降であれば、上の例のような一般化された型での表示ではなく、デフォルトの型を考慮してシンプルに表示する`:t +d`コマンドも使えます。（詳細は[こちら](https://downloads.haskell.org/%7Eghc/latest/docs/html/users_guide/ghci.html#ghci-cmd-:type%20+d%20%E2%9F%A8expression%E2%9F%A9)）
+GHC8.2以降であれば、上の例のような一般化された型での表示ではなく、デフォルトの型を考慮してシンプルに表示する`:t +d`コマンドも使えます。（詳細は[こちら](https://downloads.haskell.org/%7Eghc/latest/docs/html/users_guide/ghci.html#ghci-cmd-:type%20+d)）
 ```
 $ ghc -e ':t +d foldl'
 foldl :: (b -> a -> b) -> b -> [a] -> b

--- a/preprocessed-site/posts/2017/12-ghc-show-info.md
+++ b/preprocessed-site/posts/2017/12-ghc-show-info.md
@@ -946,7 +946,7 @@ Happy Hacking!
 [cmp_-v]: https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/using.html?highlight=#ghc-flag--v
 
 
-[cmp_-rtsopts]: https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/phases.html?highlight=#ghc-flag--rtsopts
+[cmp_-rtsopts]: https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/phases.html?highlight=#ghc-flag--rtsopts[=%E2%9F%A8none|some|all%E2%9F%A9]
 [cmp_-prof]: https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/profiling.html?highlight=#ghc-flag--prof
 [cmp_-fprof-auto]: https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/profiling.html?highlight=#ghc-flag--fprof-auto
 [cmp_-fhpc]: https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/profiling.html?highlight=#ghc-flag--fhpc

--- a/preprocessed-site/posts/2017/12-ghc-show-info.md
+++ b/preprocessed-site/posts/2017/12-ghc-show-info.md
@@ -920,7 +920,7 @@ Happy Hacking!
 
 
 [ghci_t]: https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/ghci.html#ghci-cmd-:type
-[ghci_t_+d]: https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/ghci.html#ghci-cmd-:type%20+d%20%E2%9F%A8expression%E2%9F%A9
+[ghci_t_+d]: https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/ghci.html#ghci-cmd-:type%20+d
 [ghci_t_+v]: https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/ghci.html#ghci-cmd-:type%20+v
 [ghci_k]: https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/ghci.html#ghci-cmd-:kind
 [ghci_i]: https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/ghci.html#ghci-cmd-:info


### PR DESCRIPTION
ghc8.2.2での、本家users_guideのリンク修正に併せて修正しました。
