### PR TITLE
記事のライセンスを、記事を書いた人によるCC-BYに変更

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,1 @@
+**記事を寄稿していただける場合や、既存の記事を修正をされる場合は、予め https://github.com/haskell-jp/blog/blob/master/CONTRIBUTING.md#記事のライセンスについて をよく読み、同意してください**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,3 @@
+<!--
 **記事を寄稿していただける場合や、既存の記事を修正をされる場合は、予め https://github.com/haskell-jp/blog/blob/master/CONTRIBUTING.md#記事のライセンスについて をよく読み、同意してください**
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,25 @@
 # 記事を寄稿する方法
 
-Haskell-jp Blogの寄稿に興味を持っていただいてありがとうございます！
+Haskell-jp Blogの寄稿に興味を持っていただいてありがとうございます！  
+記事を寄稿していただける場合、下記の流れで行います。
 
-寄稿する場合、[こちらのディレクトリー](https://github.com/haskell-jp/blog/tree/master/preprocessed-site/posts/)以下に、markdown形式で記事を置き、このリポジトリーにPull requestを送ってください。  
-その他、細かい点はレビュー時に指摘させていただきます。
+1. 投稿したい人が、[preprocessed-site/posts/](https://github.com/haskell-jp/blog/tree/master/preprocessed-site/posts/)というディレクトリーに、Markdownで記事を書いて置いてください。
+    - GitHubのアカウントをお持ちであれば、上記のリンク先にある、"Create new file"というボタンから追加できるはずです。
+    - 記事の先頭に書く内容などは、同じディレクトリーにある、適当なほかの記事を参考にしてください。
+    - 内部でPandocを使用しているので、[Pandocがサポートしている構文](http://pandoc.org/MANUAL.html#pandocs-markdown)であれば、すべて利用できます。
+1. 作成した記事を含めたコミットで、Pull requestを送ってください。先ほどの"Create new file"というボタンからの導線に従えば、割と簡単にできるはずです。
+1. [GitHubのHaskell-jp organization](https://github.com/haskell-jp)に所属する人などが、記事をレビューします。適宜対応してください。
+1. 送ったPull requestがマージされると、CIが自動で記事を公開してくれます！
+    - [諸般の事情](https://github.com/haskell-jp/blog/issues/54)により、このときのビルドは現状Travis CIが実行します。
 
-詳しくは[README](./README.md)もご覧ください。
+# 記事のライセンスについて
+
+原則として、次のルールが適用されます。
+
+- 寄稿者が執筆した記事の著作権は、**寄稿者のもの**となります。
+- その上で、寄稿者が執筆した記事に対しては、**「[クリエイティブ・コモンズ 表示 4.0 国際 ライセンス](https://creativecommons.org/licenses/by/4.0/)（通称CC-BY 4.0）」**が適用されます。
+    - 従って、Haskell-jp Blogに公開される記事は、寄稿者以外の人が、寄稿者の名前を表示させた上で、自由に再配布したり、改変したりすることができるという点を、あらかじめご了承ください。
+    - 詳細は[クリエイティブ・コモンズ 表示 4.0 国際 ライセンスの条文](https://creativecommons.org/licenses/by/4.0/legalcode.ja)をご覧ください。
+- ただし、寄稿者以外の人がGitHubのPull requestやIssue報告などを通じて寄稿者の記事を修正する場合、著作権は、**記事の著作者の同意の下、記事の寄稿者に委譲**するものとします。Pull requestを送った人や、Issueを報告した人のものとはなりません。
+
+もし記事のライセンスについて、何かしら特別な事情がある場合、GitHubのIssueを通じてご相談ください。例外的な対応も、適宜検討します。

--- a/README.md
+++ b/README.md
@@ -10,18 +10,12 @@
 # 記事の投稿方法
 
 Haskell-jp Blogの寄稿に興味を持っていただいてありがとうございます！  
-寄稿される場合は下記の手順で行ってください。  
 基本的には投稿する人は、**Markdownで記事を書いて、Pull requestを送るだけ**です！
 
-1. 投稿したい人が、[preprocessed-site/posts/](https://github.com/haskell-jp/blog/tree/master/preprocessed-site/posts/)というディレクトリーに、Markdownで記事を書いて置いてください。
-    - GitHubのアカウントをお持ちであれば、上記のリンク先にある、"Create new file"というボタンから追加できるはずです。
-    - 記事の先頭に書く内容などは、同じディレクトリーにある、適当なほかの記事を参考にしてください。
-    - 内部でPandocを使用しているので、[Pandocがサポートしている構文](http://pandoc.org/MANUAL.html#pandocs-markdown)であれば、すべて利用できます。
-1. 作成した記事を含めたコミットで、Pull requestを送ってください。先ほどの"Create new file"というボタンからの導線に従えば、割と簡単にできるはずです。
-1. [GitHubのHaskell-jp organization](https://github.com/haskell-jp)に所属する人などが、記事をレビューします。適宜対応してください。
-1. 送ったPull requestがマージされると、CIが自動で記事を公開してくれます！
-    - [諸般の事情](https://github.com/haskell-jp/blog/issues/54)により、このときのビルドは現状Travis CIが実行します。
+詳しい方法や、あなたが書いた記事に適用されるライセンスについては[CONTRIBUTING.md](./CONTRIBUTING.md)をご覧ください。
 
 # 記事の内容や、ウェブサイトの構成などについての問題があった場合
 
-その他、記事の内容や、ウェブサイトの構成などについての問題があった場合、[GitHubのissue](https://github.com/haskell-jp/blog/issues/new)でご連絡ください。
+その他、記事の内容や、ウェブサイトの構成などについての問題があった場合、[GitHubのissue](https://github.com/haskell-jp/blog/issues/new)でご連絡ください。  
+なお、既存の記事を修正される場合、修正内容についての著作権は、原則として、記事を元の寄稿者のものとなるのでご注意ください。  
+詳細は、[CONTRIBUTING.mdのライセンスについての注記](./CONTRIBUTING.md#記事のライセンスについて)をご覧ください。

--- a/preprocessed-site/css/style.css
+++ b/preprocessed-site/css/style.css
@@ -1,6 +1,10 @@
-.notice-ga {
+.notice {
   font-size: 70%;
-  margin-top: 1em;
+  margin-top: 0.5em;
+}
+
+span.author {
+  margin-right: 1em;
 }
 
 span.meta {

--- a/preprocessed-site/index.html
+++ b/preprocessed-site/index.html
@@ -1,5 +1,6 @@
 ---
 title: Haskell-jp Blog
+author: Haskell-jp
 headingBackgroundImage: ./img/home-bg.jpg
 headingDivClass: site-heading
 heading: Haskell-jp Blog

--- a/preprocessed-site/posts/2017/01-first.md
+++ b/preprocessed-site/posts/2017/01-first.md
@@ -3,7 +3,7 @@ title: 日本Haskellユーザーグループ発足・Slackチーム開放のお�
 headingBackgroundImage: ../../img/post-bg.jpg
 headingDivClass: post-heading
 subHeading: もくもく会を添えて
-postedBy: Haskell-jp
+author: Haskell-jp
 tags: Haskell-jp
 date: April 30, 2017
 ...

--- a/preprocessed-site/posts/2017/02-haskell-on-heroku.md
+++ b/preprocessed-site/posts/2017/02-haskell-on-heroku.md
@@ -4,6 +4,7 @@ headingBackgroundImage: ../../img/post-bg.jpg
 headingDivClass: post-heading
 heading: Dockerを使ってHaskellアプリをHerokuにデプロイする
 subHeading: コンパイル時間に制限されないデプロイ方法
+author: Kadzuya Okamoto
 postedBy: <a href="https://arow.info#arowM">Kadzuya Okamoto</a>
 date: April 30, 2017
 tags: Localize, Heroku

--- a/preprocessed-site/posts/2017/03-haskell-antenna.md
+++ b/preprocessed-site/posts/2017/03-haskell-antenna.md
@@ -2,7 +2,7 @@
 title: Haskell Antenna を公開しました
 headingBackgroundImage: ../../img/post-bg.jpg
 headingDivClass: post-heading
-postedBy: Tatsuya Hirose
+author: Tatsuya Hirose
 date: May 21, 2017
 tags: Haskell-jp
 ...

--- a/preprocessed-site/posts/2017/04-slack-archive.md
+++ b/preprocessed-site/posts/2017/04-slack-archive.md
@@ -3,7 +3,7 @@ title: SlackArchiveを導入しました
 headingBackgroundImage: ../../img/post-bg.jpg
 headingDivClass: post-heading
 subHeading: 発言が1万件を越えて保存・公開されるようになります！
-postedBy: Haskell-jp
+author: Haskell-jp
 tags: Haskell-jp
 date: May 25, 2017
 ...

--- a/preprocessed-site/posts/2017/05-subreddit.md
+++ b/preprocessed-site/posts/2017/05-subreddit.md
@@ -3,7 +3,7 @@ title: Haskell-jp 公式subreddit作成のお知らせ
 headingBackgroundImage: ../../img/post-bg.jpg
 headingDivClass: post-heading
 subHeading: 今後は質問や議論はr/haskell_jpで行うのを推奨します。
-postedBy: Haskell-jp
+author: Haskell-jp
 tags: Haskell-jp
 date: June 18, 2017
 ...

--- a/preprocessed-site/posts/2017/06-ghc-install.md
+++ b/preprocessed-site/posts/2017/06-ghc-install.md
@@ -2,7 +2,7 @@
 title: 素のGHCをローカルディレクトリにインストールする方法
 headingBackgroundImage: ../../img/post-bg.jpg
 headingDivClass: post-heading
-postedBy: takenbu.hs
+author: takenbu.hs
 date: August 8, 2017
 ...
 ---

--- a/preprocessed-site/posts/2017/07-TypedHoles.md
+++ b/preprocessed-site/posts/2017/07-TypedHoles.md
@@ -2,7 +2,7 @@
 title: GHCのTyped Holes機能で、式中の部分の型を推論させる
 headingBackgroundImage: ../../img/post-bg.jpg
 headingDivClass: post-heading
-postedBy: takenbu.hs
+author: takenbu.hs
 date: August 8, 2017
 ...
 ---

--- a/preprocessed-site/posts/2017/08-ghc-4way-execution.md
+++ b/preprocessed-site/posts/2017/08-ghc-4way-execution.md
@@ -3,7 +3,7 @@ title: GHCの４つの実行方法
 headingBackgroundImage: ../../img/post-bg.jpg
 headingDivClass: post-heading
 subHeading: コンパイル実行、スクリプト的実行、対話的実行、ワンライナー的実行
-postedBy: takenbu.hs
+author: takenbu.hs
 date: August 13, 2017
 ...
 ---

--- a/preprocessed-site/posts/2017/09-ghc-users-guide.md
+++ b/preprocessed-site/posts/2017/09-ghc-users-guide.md
@@ -3,7 +3,7 @@ title: GHCのユーザーズガイドへのリンク集
 headingBackgroundImage: ../../img/post-bg.jpg
 headingDivClass: post-heading
 subHeading: コンパイル時オプション、実行時オプション、対話コマンド、言語拡張など
-postedBy: takenbu.hs
+author: takenbu.hs
 date: August 14, 2017
 ...
 ---

--- a/preprocessed-site/posts/2017/10-about-kind-system-part1.md
+++ b/preprocessed-site/posts/2017/10-about-kind-system-part1.md
@@ -3,7 +3,7 @@ title: About kind system of Haskell (Part 1)
 headingBackgroundImage: ../../img/post-bg.jpg
 headingDivClass: post-heading
 subHeading: 種の仕組みとそれに付随する言語拡張について
-postedBy: mizunashi-mana
+author: mizunashi-mana
 date: August 23, 2017
 ...
 ---

--- a/preprocessed-site/posts/2017/11-haskell-newbies-talks.md
+++ b/preprocessed-site/posts/2017/11-haskell-newbies-talks.md
@@ -3,6 +3,7 @@ title: Haskell-jp現在の活動・目的総ざらい
 headingBackgroundImage: ../../img/post-bg.jpg
 headingDivClass: post-heading
 subHeading: Haskell入門者LT会での発表内容の再共有です
+author: Yuji Yamamoto
 postedBy: <a href="http://the.igreque.info/">Yuji Yamamoto(@igrep)</a>
 date: August 30, 2017
 ...

--- a/preprocessed-site/posts/2017/12-ghc-show-info.md
+++ b/preprocessed-site/posts/2017/12-ghc-show-info.md
@@ -3,7 +3,7 @@ title: GHCにおける多彩な情報の出力方法
 headingBackgroundImage: ../../img/post-bg.jpg
 headingDivClass: post-heading
 subHeading: 対話操作による出力、コンパイル時出力、実行時出力
-postedBy: takenbu.hs
+author: takenbu.hs
 date: September 10, 2017
 ...
 ---

--- a/preprocessed-site/posts/2017/13-about-kind-system-part2.md
+++ b/preprocessed-site/posts/2017/13-about-kind-system-part2.md
@@ -3,7 +3,7 @@ title: Haskellの種(kind)について (Part 2)
 headingBackgroundImage: ../../img/post-bg.jpg
 headingDivClass: post-heading
 subHeading: 種の仕組みとそれに付随する言語拡張について
-postedBy: mizunashi-mana
+author: mizunashi-mana
 date: September 18, 2017
 ...
 ---

--- a/preprocessed-site/posts/2017/no-stack-build.md
+++ b/preprocessed-site/posts/2017/no-stack-build.md
@@ -3,7 +3,7 @@ title: Haskell-jp Blogへの投稿が簡単になりました！
 headingBackgroundImage: ../../img/post-bg.jpg
 headingDivClass: post-heading
 subHeading: Advent Calendarの記事の投稿も募集しております！
-postedBy: Haskell-jp
+author: Haskell-jp
 tags: Haskell-jp, CircleCI, Travis CI
 date: November 27, 2017
 ...

--- a/preprocessed-site/posts/about_us.md
+++ b/preprocessed-site/posts/about_us.md
@@ -3,7 +3,7 @@ title: Haskellと日本Haskellユーザーグループについて
 headingBackgroundImage: ../img/post-bg.jpg
 headingDivClass: post-heading
 heading: Haskellと日本Haskellユーザーグループについて
-postedBy: Haskell-jp
+author: Haskell-jp
 date: April 30, 2017
 tags: Haskell-jp
 ...

--- a/preprocessed-site/posts/links.md
+++ b/preprocessed-site/posts/links.md
@@ -3,7 +3,7 @@ title: 相互リンク集
 headingBackgroundImage: ../img/post-bg.jpg
 headingDivClass: post-heading
 subHeading: Haskell-jpが応援するWebサイト一覧
-postedBy: Haskell-jp
+author: Haskell-jp
 date: May 18, 2017
 ...
 ---

--- a/preprocessed-site/posts/template.md
+++ b/preprocessed-site/posts/template.md
@@ -3,7 +3,8 @@ title: 記事のタイトル
 headingBackgroundImage: ../img/post-bg.jpg
 headingDivClass: post-heading
 subHeading: （副題が必要な場合はこちらを）
-postedBy: <a href="">（あなたの名前。このようにHTMLタグを含めることもできます。）</a>
+author: （あなたの名前。HTMLのmetaタグの`author`や、フッターにおけるコピーライトマークの箇所に使用されます）
+postedBy: <a href="">（記事一覧や見出しに載る、あなたの名前。authorと異なり、このようにHTMLタグを含めることもできます。省略した場合、`author`の内容が使用されます）</a>
 date: April 29, 2017 # 公開日。仮でよいので埋めてください。
 draft: true # この行は原則として削除してください。
 ...

--- a/preprocessed-site/templates/default.html
+++ b/preprocessed-site/templates/default.html
@@ -124,8 +124,8 @@
                             </a>
                         </li>
                     </ul>
-                    <div class="text-muted notice text-center"> <br/><span class="author">&copy; $author$ 2017</span> <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="クリエイティブ・コモンズ・ライセンス" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a></div>
-                    <div class="text-muted notice text-center">この作品は<a rel="license" href="http://creativecommons.org/licenses/by/4.0/">クリエイティブ・コモンズ 表示 4.0 国際 ライセンス</a>の下に提供されています。</div>
+                    <div class="text-muted notice text-center"> <br/><span class="author">&copy; $author$ 2017</span> <a rel="license" href="https://creativecommons.org/licenses/by/4.0/deed.ja"><img alt="クリエイティブ・コモンズ・ライセンス" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a></div>
+                    <div class="text-muted notice text-center">この作品は<a rel="license" href="https://creativecommons.org/licenses/by/4.0/deed.ja">クリエイティブ・コモンズ 表示 4.0 国際 ライセンス</a>の下に提供されています。</div>
                     <p class="text-muted notice">
                       当ウェブサイトでは<a href="https://support.google.com/analytics/answer/6004245?hl=ja">Google Analytics</a>でアクセス情報を収集しています。集めた情報は統計的に処理した上で、当ウェブサイトの改善のための参考情報としてのみ使用します。
                     </p>

--- a/preprocessed-site/templates/default.html
+++ b/preprocessed-site/templates/default.html
@@ -7,7 +7,11 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="$title$">
-    <meta name="author" content="Haskell-jp">
+    $if(author)$
+      <meta name="author" content="$author$">
+    $else$
+      <meta name="author" content="Haskell-jp">
+    $endif$
 
     <!-- OGP Settings -->
     <meta property="og:title" content="$title$ - Haskell-jp" />
@@ -120,8 +124,11 @@
                             </a>
                         </li>
                     </ul>
-                    <p class="copyright text-muted">&copy; Haskell-jp 2017</p>
-                    <small class="text-muted notice-ga">当ウェブサイトでは<a href="https://support.google.com/analytics/answer/6004245?hl=ja">Google Analytics</a>でアクセス情報を収集しています。集めた情報は統計的に処理した上で、当ウェブサイトの改善のための参考情報としてのみ使用します。</small>
+                    <div class="text-muted notice text-center"> <br/><span class="author">&copy; $author$ 2017</span> <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="クリエイティブ・コモンズ・ライセンス" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a></div>
+                    <div class="text-muted notice text-center">この作品は<a rel="license" href="http://creativecommons.org/licenses/by/4.0/">クリエイティブ・コモンズ 表示 4.0 国際 ライセンス</a>の下に提供されています。</div>
+                    <p class="text-muted notice">
+                      当ウェブサイトでは<a href="https://support.google.com/analytics/answer/6004245?hl=ja">Google Analytics</a>でアクセス情報を収集しています。集めた情報は統計的に処理した上で、当ウェブサイトの改善のための参考情報としてのみ使用します。
+                    </p>
                 </div>
             </div>
         </div>

--- a/preprocessed-site/templates/post-list.html
+++ b/preprocessed-site/templates/post-list.html
@@ -12,7 +12,11 @@ $for(posts)$
             </h3>
             $endif$
         </a>
-        <p class="post-meta">Posted by $postedBy$ on $date$</p>
+        $if(postedBy)$
+          <p class="post-meta">Posted by $postedBy$ on $date$</p>
+        $else$
+          <p class="post-meta">Posted by $author$ on $date$</p>
+        $endif$
     </div>
     <!-- Remove the hr for the time being because it looks weird.  We might have
     to fix it if we ever have more than one post. -->

--- a/src/site.hs
+++ b/src/site.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-import Control.Applicative (empty)
+import Control.Applicative (empty, (<|>))
 import Control.Monad (filterM)
 import Data.Char (isLatin1)
 import Data.Data (Data)
@@ -131,11 +131,13 @@ createOpenGraphDescription _ = convert . itemBody <$> getResourceBody
 createSubHeadingContentForPost :: Item a -> Compiler String
 createSubHeadingContentForPost item = do
     let ident = itemIdentifier item
-    subHeading <- fromMaybe "" <$> getMetadataField ident "subHeading"
-    postedBy   <- getMetadataField' ident "postedBy"
-    date       <- getMetadataField' ident "date"
-    mtags      <- getMetadataField ident "tags"
+    subHeading    <- fromMaybe "" <$> getMetadataField ident "subHeading"
+    maybeAuthor   <- getMetadataField ident "author"
+    maybePostedBy <- getMetadataField ident "postedBy"
+    date          <- getMetadataField' ident "date"
+    mtags         <- getMetadataField ident "tags"
     let subHeadingHtml = "<h2 class=\"subheading\">" ++ subHeading ++ "</h2>"
+        postedBy = fromMaybe "" (maybePostedBy <|> maybeAuthor)
         postedByHtml = "<span class=\"meta\">Posted by " ++ postedBy ++ " on " ++ date ++  "</span>"
         tagsHtml = maybe "" (\tags -> "<span class=\"meta\">Tags: " ++ tags ++ "</span>") mtags
     return $ subHeadingHtml ++ postedByHtml ++ tagsHtml

--- a/src/site.hs
+++ b/src/site.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-import Control.Applicative (empty, (<|>))
+import Control.Applicative (empty)
 import Control.Monad (filterM)
 import Data.Char (isLatin1)
 import Data.Data (Data)
@@ -132,12 +132,12 @@ createSubHeadingContentForPost :: Item a -> Compiler String
 createSubHeadingContentForPost item = do
     let ident = itemIdentifier item
     subHeading    <- fromMaybe "" <$> getMetadataField ident "subHeading"
-    maybeAuthor   <- getMetadataField ident "author"
+    author        <- getMetadataField' ident "author"
     maybePostedBy <- getMetadataField ident "postedBy"
     date          <- getMetadataField' ident "date"
     mtags         <- getMetadataField ident "tags"
     let subHeadingHtml = "<h2 class=\"subheading\">" ++ subHeading ++ "</h2>"
-        postedBy = fromMaybe "" (maybePostedBy <|> maybeAuthor)
+        postedBy = fromMaybe author maybePostedBy
         postedByHtml = "<span class=\"meta\">Posted by " ++ postedBy ++ " on " ++ date ++  "</span>"
         tagsHtml = maybe "" (\tags -> "<span class=\"meta\">Tags: " ++ tags ++ "</span>") mtags
     return $ subHeadingHtml ++ postedByHtml ++ tagsHtml


### PR DESCRIPTION
https://github.com/haskell-jp/blog/issues/59 で議論した内容に基づいて、下記の修正を加えました。

- 記事のライセンスや投稿手順について、CONTRIBUTING.mdにまとめて明記
    - CONTRIBUTING.md は、GitHubの仕様上Pull requestを送る際にも見るよう促されるものなので、こちらに書くことにしました。
    - 方針がころころ変わるようですが、投稿手順についても同様の理由でREADMEから移動させました。
    - ダメ押しで、.github/PULL_REQUEST_TEMPLATE.mdにおいても参照するよう明記しました。
- HTMLの`meta`タグや、フッターにおける著作者名として、`author`メタデータを使うよう設定しました。
    - 従来の`postedBy`は書いた人がお好みで`a`タグを挟んだり、著作者名にTwitterアカウントなどを追記する、というような運用をしていたため、`postedBy`とは別に設定できることにしました。今後は`author`メタデータが必須となり、`postedBy`メタデータが明記されていない場合、代わりに`author`メタデータの値が使用されることになります。
- 記事のフッターに[クリエイティブコモンズ証](https://creativecommons.org/licenses/by/4.0/deed.ja)を追記
    - なお、[クリエイティブコモンズの要件](https://creativecommons.org/choose/results-one?license_code=by&amp;jurisdiction=&amp;version=4.0&amp;lang=ja)としては特に明記する必要はないみたいですが、クリエイティブコモンズな作品も立派に著作権で守られたものなので、ベルヌ条約未加入の国のことも考慮し、念のためコピーライトマークを付与することにしました。
        - [参考](https://ja.wikipedia.org/w/index.php?title=%E8%91%97%E4%BD%9C%E6%A8%A9&oldid=66364485#著作権の発生要件)