### PR TITLE
Refactor circle.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 general:
   artifacts:
     - "generated-site/"
-_cache_and_artifacts: &_cache_and_artifacts
+_cache: &_cache
   cache_directories:
     - "~/.stack/"
     - ".stack-work/"
@@ -10,19 +10,18 @@ dependencies:
   override:
     - stack setup
     - stack install --only-dependencies
-  <<: *_cache_and_artifacts
+  <<: *_cache
 
 compile:
   override:
     - stack build --pedantic
     - stack exec -- site build
-    - cp -r generated-site $CIRCLE_ARTIFACTS
-  <<: *_cache_and_artifacts
+  <<: *_cache
 
 test:
   override:
     - stack test --pedantic
-  <<: *_cache_and_artifacts
+  <<: *_cache
 
 deployment:
   production:


### PR DESCRIPTION
- 実際にはartifactsの情報を含まないにも関わらず `_cache_and_artifacts` という参照になっていたため修正
- 二重にartifactsのディレクトリーを作っていたため無駄なコピーを削除

<!--
**記事を寄稿していただける場合や、既存の記事を修正をされる場合は、予め https://github.com/haskell-jp/blog/blob/master/CONTRIBUTING.md#記事のライセンスについて をよく読み、同意してください**
-->
