### PR TITLE
resolver を lts-10 系にアップデート

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ cache:
 addons:
   apt:
     packages:
-    - ghc-8.0.2
+    - ghc-8.2.2
     - libgmp-dev
     sources:
     - hvr-ghc

--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,7 @@ _cache: &_cache
 
 dependencies:
   override:
+    - stack upgrade
     - stack setup
     - stack install --only-dependencies
   <<: *_cache

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,4 +2,4 @@ flags: {}
 packages:
 - '.'
 extra-deps: []
-resolver: lts-8.5
+resolver: lts-10.9

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,7 @@
 flags: {}
 packages:
 - '.'
-extra-deps: []
+extra-deps:
+- hakyll-4.11.0.0
+- pandoc-citeproc-0.13.0.1
 resolver: lts-10.9


### PR DESCRIPTION
see: #95 

`resolver` 以外に書き換えてる理由:

- `extra-deps` の設定は[この問題](https://github.com/jaspervdj/hakyll/issues/612)のため
- CircleCI に標準で入ってる(?) stack は古く(v1.5 ぐらい) [lts-10 ではエラーが出る](https://github.com/fpco/stackage/issues/3132)ため `stack upgrade` している
    - 実は `stack upgrade` のときに[このエラーが出る](https://github.com/commercialhaskell/stack/issues/3900)ことも
    - rebuild すると起きなかったのでとりあえず放置
    - そもそも [CircleCI 1.0 は終わる](https://circleci.com/blog/sunsetting-1-0/)し `circleci.yml` を改修しないと...

あと、TravisCI はデプロイのときにしか動かないので未検証...