### PR TITLE
Feed を生成するようにした

### DIFF
--- a/preprocessed-site/feed.md
+++ b/preprocessed-site/feed.md
@@ -1,0 +1,7 @@
+---
+title: Haskell-jp Blog
+description: 日本Haskellユーザーグループ公式ブログ
+author: Haskell-jp
+email: ""
+root: https://haskell.jp/blog
+---

--- a/preprocessed-site/templates/default.html
+++ b/preprocessed-site/templates/default.html
@@ -12,6 +12,7 @@
     $else$
       <meta name="author" content="Haskell-jp">
     $endif$
+    <link rel="alternate" type="application/atom+xml" title="Haskell-jp Blog" href="https://haskell.jp/blog/feed.xml" />
 
     <!-- OGP Settings -->
     <meta property="og:title" content="$title$ - Haskell-jp" />


### PR DESCRIPTION
see: #94 

`https://haskell.jp/blog/feed.xml` というファイルを Hakyll の [`renderAtom`](https://hackage.haskell.org/package/hakyll-4.11.0.0/docs/Hakyll-Web-Feed.html#v:renderAtom) 関数を用いて生成します。
`feed.md` のメタ情報で [feed を生成するのに必要な情報](https://hackage.haskell.org/package/hakyll-4.11.0.0/docs/Hakyll-Web-Feed.html#t:FeedConfiguration)を渡しています。

(理想的には `config.yaml` って感じのファイルが欲しいですよね...)
