### PR TITLE
Copyright の年を2017年固定から記事の発行年に修正

### DIFF
--- a/preprocessed-site/index.html
+++ b/preprocessed-site/index.html
@@ -7,6 +7,7 @@ heading: Haskell-jp Blog
 subHeadingContent: <hr class="small">
                    <span class="subheading">日本Haskellユーザーグループ公式ブログ</span>
 description: 日本Haskellユーザーグループ公式ブログ
+year: 2017
 ---
 <div class="container">
     <div class="row">

--- a/preprocessed-site/templates/default.html
+++ b/preprocessed-site/templates/default.html
@@ -127,7 +127,7 @@
                             </a>
                         </li>
                     </ul>
-                    <div class="text-muted notice text-center"> <br/><span class="author">&copy; $author$ 2017</span> <a rel="license" href="https://creativecommons.org/licenses/by/4.0/deed.ja"><img alt="クリエイティブ・コモンズ・ライセンス" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a></div>
+                    <div class="text-muted notice text-center"> <br/><span class="author">&copy; $author$ $year$</span> <a rel="license" href="https://creativecommons.org/licenses/by/4.0/deed.ja"><img alt="クリエイティブ・コモンズ・ライセンス" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a></div>
                     <div class="text-muted notice text-center">この作品は<a rel="license" href="https://creativecommons.org/licenses/by/4.0/deed.ja">クリエイティブ・コモンズ 表示 4.0 国際 ライセンス</a>の下に提供されています。</div>
                     <p class="text-muted notice">
                       当ウェブサイトでは<a href="https://support.google.com/analytics/answer/6004245?hl=ja">Google Analytics</a>でアクセス情報を収集しています。集めた情報は統計的に処理した上で、当ウェブサイトの改善のための参考情報としてのみ使用します。

--- a/src/site.hs
+++ b/src/site.hs
@@ -109,6 +109,7 @@ main = hakyllWith hakyllConfig $ do
 -- | For posts, add a @date@ field to the default context.
 postCtx :: Context String
 postCtx = dateField "date" "%B %e, %Y" `mappend`
+          dateField "year" "%Y" `mappend`
           defaultContext
 
 -- | Apply the default template and then relativize all the URLs in the


### PR DESCRIPTION
<!--
**記事を寄稿していただける場合や、既存の記事を修正をされる場合は、予め https://github.com/haskell-jp/blog/blob/master/CONTRIBUTING.md#記事のライセンスについて をよく読み、同意してください**
-->
see: #104 

- 記事は Context として渡す
- 記事以外(`index.html`)はメタデータに記述