### PR TITLE
Fix minor formatting issue on English posts

### DIFF
--- a/preprocessed-site/posts/2018/windows-gotchas-en.md
+++ b/preprocessed-site/posts/2018/windows-gotchas-en.md
@@ -7,6 +7,7 @@ author: Yuji Yamamoto
 postedBy: <a href="http://the.igreque.info/">Yuji Yamamoto(@igrep)</a>
 date: May 25, 2018
 tags: Windows
+language: en
 ...
 ---
 

--- a/src/site.hs
+++ b/src/site.hs
@@ -152,11 +152,17 @@ createSubHeadingContentForPost item = do
     maybePostedBy <- getMetadataField ident "postedBy"
     date          <- getMetadataField' ident "date"
     mtags         <- getMetadataField ident "tags"
+    language      <- fromMaybe "ja" <$> getMetadataField ident "language"
     let subHeadingHtml = "<h2 class=\"subheading\">" ++ subHeading ++ "</h2>"
         postedBy = fromMaybe author maybePostedBy
         postedByHtml = "<span class=\"meta\">Posted by " ++ postedBy ++ " on " ++ date ++  "</span>"
         tagsHtml = maybe "" (\tags -> "<span class=\"meta\">Tags: " ++ tags ++ "</span>") mtags
-    return $ subHeadingHtml ++ postedByHtml ++ tagsHtml
+        langStyle = getLanguageStyle language
+    return $ subHeadingHtml ++ postedByHtml ++ tagsHtml ++ langStyle
+
+getLanguageStyle :: String -> String
+getLanguageStyle "en" = "<style>.ascii:before,.ascii:after{content:'' !important;}</style>"
+getLanguageStyle _ = ""
 
 isDraftPost :: MonadMetadata m => Identifier -> m Bool
 isDraftPost ident = do


### PR DESCRIPTION
ブログではアポストロフィと引用符の周りにスパースが入れていますが、英語では必要ありません。例としてスクリーンショットを添付しました。

![spaces](https://user-images.githubusercontent.com/1812124/40544588-bf9afb8a-6020-11e8-9179-151293f8259b.png)
![no_spaces](https://user-images.githubusercontent.com/1812124/40544596-c5eb7b2c-6020-11e8-9271-7bf37d5439c0.png)
