### PR TITLE
Fix カンマやシングルクォートなどの前後にはスペースを入れない #119

### DIFF
--- a/preprocessed-site/posts/2018/windows-gotchas-en.md
+++ b/preprocessed-site/posts/2018/windows-gotchas-en.md
@@ -7,6 +7,7 @@ author: Yuji Yamamoto
 postedBy: <a href="http://the.igreque.info/">Yuji Yamamoto(@igrep)</a>
 date: May 25, 2018
 tags: Windows
+language: en
 ...
 ---
 


### PR DESCRIPTION
Some of this commit contains the patch of  https://github.com/haskell-jp/blog/pull/121.
Thanks @ptigwe!

<!--
**記事を寄稿していただける場合や、既存の記事を修正をされる場合は、予め https://github.com/haskell-jp/blog/blob/master/CONTRIBUTING.md#記事のライセンスについて をよく読み、同意してください**
-->
