### PR TITLE
Circle CIによるデプロイ

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,39 @@ jobs:
           curl -H 'Content-Type:application/json' -d @- \
             https://haskell-jp-blog-artifact.herokuapp.com/
         fi
-    # Circle CIからのdeployは最後に挑戦した際うまくいかなかったのでコメントアウト。
-    # 改めて試す場合、Travis CIによるデプロイと
-    # 関連: https://github.com/haskell-jp/blog/issues/54
-    #- run: "$CIRCLE_BRANCH" = master && make -e deploy
+    - persist_to_workspace:
+        root: .
+        paths:
+          - ./generated-site
+
+  deploy:
+    docker:
+    - image: haskell:8.2.1
+    steps:
+    - checkout:
+        path: ~/project
+    - add-ssh-keys:
+        fingerprints:
+          - "ce:26:f9:6a:ac:98:43:91:5c:c8:77:ef:11:13:d3:fc"
+    - run: apt update
+    - run: apt install -y make ssh-client
+    - attach_workspace:
+       at: .
+    - run: |
+        git config --global user.email "ci@haskell.jp"
+        git config --global user.name "Circle CI User"
+        ssh-keyscan github.com >> ~/.ssh/known_hosts
+        STACK_LOCAL_INSTALL_PATH=dummy make -W site -W dummy/site -e deploy
+
+workflows:
+  version: 2
+  build_and_deploy:
+    jobs:
+      - build
+      - deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - master

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ all: site
 #############
 
 # Path to the directory that `stack` uses to install binaries locally.
-STACK_LOCAL_INSTALL_PATH = $(shell stack path --local-install-root)
+STACK_LOCAL_INSTALL_PATH ?= $(shell stack path --local-install-root)
 
 # Path to the `site` binary.
 SITE_PROG_PATH = $(STACK_LOCAL_INSTALL_PATH)/site
@@ -72,8 +72,13 @@ endif
 	git add -A .
 	git status
 	# Do the commit and push.
-	git commit -m "Release $(GIT_HASH) on `date` [ci skip]."
-	git push -f origin gh-pages
+	@git diff --exit-code; \
+	rc=$?; if [ $rc != 0 ] ; then \
+		git commit -m "Release $(GIT_HASH) on `date`."; \
+		git push -f origin gh-pages; \
+	else \
+		echo "Skip commit and push to gh-pages"; \
+	fi
 ifndef GITHUB_TOKEN
 	# Go back to master.
 	git checkout master
@@ -84,7 +89,7 @@ endif
 release: deploy
 
 # Generate the .html files for our blog.
-site: $(SITE_PROG_PATH) 
+site: $(SITE_PROG_PATH)
 	@# We don't actually need to use rebuild here, we could just use build.
 	@# If this blog becomes really big and produces tons of pages, then switching
 	@# to 'build' here (and adding an additional site-rebuild target) would be a


### PR DESCRIPTION
- circle ci上でdeployを実行するようにしました。
  - jobをbuildとdeployに分けています。
- build jobの成果物を引き継ぎたかったので、deployの依存ターゲットを実行しないようにしていて(STACK_LOCAL_INSTALL_PATHの上書き)、ここがイマイチ感あります。指摘あればお願いします。
- デプロイにpersonal access tokenを使わずdeploy keyを使うように変更しています（key名: Circle CI Deploy）。