### PR TITLE
Fix code block style

### DIFF
--- a/preprocessed-site/css/style.css
+++ b/preprocessed-site/css/style.css
@@ -149,3 +149,17 @@ span.link-to-here-outer:hover a .link-to-here {
   visibility: visible;
 }
 
+/*
+ * Overwrite bootstrap styles for skylighting
+ */
+div.sourceCode {
+  background-color: #f5f5f5;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+pre.sourceCode {
+  background-color: unset;
+  border: unset;
+  border-radius: unset;
+}


### PR DESCRIPTION
resolve #134 

これは，skylightingのoverflow設定も原因の1つですが，どちらかというとbootstrapのstyleとの相性が問題のようです．

skylightingのoverflow設定は，
https://github.com/jgm/skylighting/blob/3238154b390da1fe62a89ab1b3820c1dedd9366b/skylighting-core/src/Skylighting/Format/HTML.hs#L178
にあるようにline numberを使う場合のための設定です．ただ，bootstrapはpreタグに背景カラーなどを設定しますが，おそらくこのような用途は想定しないということだと思います．

なので，bootstrapのスタイルをこちら側で修正するのが，通常の対応のような気がします．

ところでbootstrap 4ではこれらの問題を鑑みてpreへのカラーリングの適用は取りやめていて，通常はそれぞれのサイトのスタイルでカラーリングを適用するのが一般的です．