### PR TITLE
Add dummy workflows to CI config for gh-pages

### DIFF
--- a/preprocessed-site/.circleci/config.yml
+++ b/preprocessed-site/.circleci/config.yml
@@ -1,2 +1,4 @@
 version: 2
 jobs: {}
+workflows:
+  version: 2


### PR DESCRIPTION
Fix #141 

すいません，空のworkflowsも含めないとダメみたいです．

サンプルは， https://github.com/mizunashi-mana/github-test/commits/51dbc6f1eb2f3d493fbd9d4d49332b3837ded777 にあります．一番上がworkflowsを追加したもので，その前がjobsしかないものです
