### PR TITLE
Slack招待用リンクの修正

### DIFF
--- a/preprocessed-site/posts/2017/01-first.md
+++ b/preprocessed-site/posts/2017/01-first.md
@@ -18,7 +18,7 @@ date: April 30, 2017
 Haskell-jp立ち上げ前、有志による議論に使用していたSlackチームを開放します！  
 下記から登録してください！
 
-<https://join-haskell-jp-slack.herokuapp.com/>
+<https://join.slack.com/t/haskell-jp/shared_invite/enQtNDY4Njc1MTA5MDQxLTAzZGNkZDlkMWYxZDRlODI3NmNlNTQ1ZDc3MjQxNzg3OTg4YzUzNmUyNmU5YWVkMjFmMjFjYzk1OTE3Yzg4ZTM>
 
 現時点の運用ルールは、以下のとおりです。
 

--- a/preprocessed-site/posts/2017/05-subreddit.md
+++ b/preprocessed-site/posts/2017/05-subreddit.md
@@ -29,7 +29,7 @@ date: June 18, 2017
 
 ## 今後について: Slackとの使い分けは？
 
-さて、これまで[Haskell-jpのSlack](https://join-haskell-jp-slack.herokuapp.com/)では[questionsチャンネル](https://haskell-jp.slackarchive.io/questions/)を中心に、Haskellに関する数々の質問や相談が、短い期間ながら行われてきました。[randomチャンネル](https://haskell-jp.slackarchive.io/random/)などでのウェブサイトの共有もたくさんありました。
+さて、これまで[Haskell-jpのSlack](https://join.slack.com/t/haskell-jp/shared_invite/enQtNDY4Njc1MTA5MDQxLTAzZGNkZDlkMWYxZDRlODI3NmNlNTQ1ZDc3MjQxNzg3OTg4YzUzNmUyNmU5YWVkMjFmMjFjYzk1OTE3Yzg4ZTM)では[questionsチャンネル](https://haskell-jp.slackarchive.io/questions/)を中心に、Haskellに関する数々の質問や相談が、短い期間ながら行われてきました。[randomチャンネル](https://haskell-jp.slackarchive.io/random/)などでのウェブサイトの共有もたくさんありました。
 今後は、[Haskell-jpのsubreddit](https://www.reddit.com/r/haskell_jp/)でお悩み相談や議論を行うとして、Slackチームはどうなってしまうのでしょうか？
 
 ざっくり結論から申しますと、「好きな方を使え」というのが公式の見解です。  
@@ -43,4 +43,4 @@ Slackはもともとの日本における人気の高さも手伝い、Haskell-j
 - 前項にかかわらず、Slackに慣れているから、Slackのemoji reactionのほうが楽しいから、といった場合はSlackをご利用ください。
 - ちなみに、もちろんteratailやStackOverflowでの質問もよいでしょう。本日から、Slackの[questions-feedチャンネル](https://haskell-jp.slack.com/messages/C5UPKRGRE/convo/C4M4TT8JJ-1497217764.308002/)に質問が流れるようになりました！
 
-以上、今後も[Slackチーム](https://join-haskell-jp-slack.herokuapp.com/)、[r/haskell\_jp](https://www.reddit.com/r/haskell_jp/)ともどもよろしくお願いします！
+以上、今後も[Slackチーム](https://join.slack.com/t/haskell-jp/shared_invite/enQtNDY4Njc1MTA5MDQxLTAzZGNkZDlkMWYxZDRlODI3NmNlNTQ1ZDc3MjQxNzg3OTg4YzUzNmUyNmU5YWVkMjFmMjFjYzk1OTE3Yzg4ZTM)、[r/haskell\_jp](https://www.reddit.com/r/haskell_jp/)ともどもよろしくお願いします！

--- a/preprocessed-site/posts/2017/11-haskell-newbies-talks.md
+++ b/preprocessed-site/posts/2017/11-haskell-newbies-talks.md
@@ -32,7 +32,7 @@ markdownで書いといてよかった！ （⌒\_⌒）
 
 - いろいろしゃべったり質問したり、フィードを流したりしてます
 - リンク先は[SlackArchive](http://slackarchive.io/)を利用した発言ログ
-- 登録は[こちら](https://join-haskell-jp-slack.herokuapp.com/)から。
+- 登録は[こちら](https://join.slack.com/t/haskell-jp/shared_invite/enQtNDY4Njc1MTA5MDQxLTAzZGNkZDlkMWYxZDRlODI3NmNlNTQ1ZDc3MjQxNzg3OTg4YzUzNmUyNmU5YWVkMjFmMjFjYzk1OTE3Yzg4ZTM)から。
 
 ## 運用ルール
 

--- a/preprocessed-site/posts/2018/ghc-proposal-and-patch.md
+++ b/preprocessed-site/posts/2018/ghc-proposal-and-patch.md
@@ -186,7 +186,7 @@ GHCへの変更提案に対するコード修正は、パッチを作成して�
 ## 補足
 
 わからないことがあれば、[ghc-devsのML](https://mail.haskell.org/cgi-bin/mailman/listinfo/ghc-devs)に問い合わせると親切に教えてもらえます。
-もちろん、[Haskell-jpのslack](https://join-haskell-jp-slack.herokuapp.com/)の#questionsチャネルなどで尋ねるのも良いでしょう。
+もちろん、[Haskell-jpのslack](https://join.slack.com/t/haskell-jp/shared_invite/enQtNDY4Njc1MTA5MDQxLTAzZGNkZDlkMWYxZDRlODI3NmNlNTQ1ZDc3MjQxNzg3OTg4YzUzNmUyNmU5YWVkMjFmMjFjYzk1OTE3Yzg4ZTM)の#questionsチャネルなどで尋ねるのも良いでしょう。
 
 なお、GHCでの開発作業については、[Working on GHC](https://ghc.haskell.org/trac/ghc/wiki/WorkingConventions)も参考にどうぞ。  
 また、GHCの開発フロー全体については、[こちら](https://takenobu-hs.github.io/downloads/ghc_development_flow.pdf)も参考にどうぞ。GHC関連のサイトの情報を力づくで検索するには、[こちら](https://takenobu-hs.github.io/haskell-wiki-search/)もどうぞ。

--- a/preprocessed-site/templates/default.html
+++ b/preprocessed-site/templates/default.html
@@ -85,7 +85,7 @@
                         <a href="/">Blog</a>
                     </li>
                     <li>
-                        <a href="https://join-haskell-jp-slack.herokuapp.com/">Slack Team</a>
+                        <a href="https://join.slack.com/t/haskell-jp/shared_invite/enQtNDY4Njc1MTA5MDQxLTAzZGNkZDlkMWYxZDRlODI3NmNlNTQ1ZDc3MjQxNzg3OTg4YzUzNmUyNmU5YWVkMjFmMjFjYzk1OTE3Yzg4ZTM">Slack Team</a>
                     </li>
                     <li>
                         <a href="https://www.reddit.com/r/haskell_jp/">Reddit</a>


### PR DESCRIPTION
# 概要
Slack招待用リンクを新しいものに差し替えました

# 備考
URLが長くなったので、`preprocessed-site/posts/2017/01-first.md`ではちょっと見た目が悪くなる可能性があります。