### PR TITLE
Update docker image to build on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     # Ref: https://mmhaskell.com/blog/2018/4/25/dockerizing-our-haskell-app
     docker:
-    - image: haskell:8.2.1
+    - image: haskell:8.6.3
     steps:
     - run: apt update
     - run: apt install -y zip jq curl
@@ -18,8 +18,8 @@ jobs:
         - 'dependencies-'
     # 下記のパッケージはビルド時にメモリが不足するため、一旦 -j1 でビルドしておく
     # Ref: https://haskell.e-bigmoon.com/posts/2017/12-31-travis-out-of-memory.html
-    - run: stack build --compiler=ghc-8.2.1 --no-terminal -j1 Cabal wai-logger
-    - run: stack build --compiler=ghc-8.2.1 --no-terminal --only-dependencies
+    - run: stack build --compiler=ghc-8.6.3 --no-terminal -j1 Cabal wai-logger
+    - run: stack build --compiler=ghc-8.6.3 --no-terminal --only-dependencies
     - save_cache:
         key: 'dependencies-{{ checksum "stack.yaml" }}-{{ checksum "haskell-jp-blog.cabal" }}'
         paths:
@@ -30,7 +30,7 @@ jobs:
         keys:
         - 'executable-{{ checksum "src/site.hs" }}'
         - 'executable-'
-    - run: stack --compiler=ghc-8.2.1 --local-bin-path='.' --no-terminal install --pedantic
+    - run: stack --compiler=ghc-8.6.3 --local-bin-path='.' --no-terminal install --pedantic
     - save_cache:
         key: 'executable-{{ checksum "src/site.hs" }}'
         paths:
@@ -58,7 +58,7 @@ jobs:
 
   deploy:
     docker:
-    - image: haskell:8.2.1
+    - image: haskell:8.6.3
     steps:
     - checkout:
         path: ~/project

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,5 @@
 flags: {}
 packages:
 - '.'
-extra-deps:
-- hakyll-4.11.0.0
-- pandoc-citeproc-0.13.0.1
-resolver: lts-10.9
+extra-deps: []
+resolver: lts-13.11

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,7 @@
 flags: {}
 packages:
 - '.'
-extra-deps: []
+extra-deps:
+- hakyll-4.12.5.1
+- lrucache-1.2.0.1
 resolver: lts-13.11


### PR DESCRIPTION
https://circleci.com/gh/haskell-jp/blog/606 のビルドエラーに対する対応です。
正確な原因はわかりませんが、使っているDockerイメージが古いのが関係しているような気がしています。
<!--
**記事を寄稿していただける場合や、既存の記事を修正をされる場合は、予め https://github.com/haskell-jp/blog/blob/master/CONTRIBUTING.md#記事のライセンスについて をよく読み、同意してください**
-->
