### PR TITLE
stack resolver のバージョンを lts-16.25 にします

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     # Ref: https://mmhaskell.com/blog/2018/4/25/dockerizing-our-haskell-app
     docker:
-    - image: haskell:8.6.3
+    - image: haskell:8.8.4
     steps:
     - run: apt update
     - run: apt install -y zip jq curl
@@ -18,8 +18,8 @@ jobs:
         - 'dependencies-'
     # 下記のパッケージはビルド時にメモリが不足するため、一旦 -j1 でビルドしておく
     # Ref: https://haskell.e-bigmoon.com/posts/2017/12-31-travis-out-of-memory.html
-    - run: stack build --compiler=ghc-8.6.3 --no-terminal -j1 Cabal wai-logger
-    - run: stack build --compiler=ghc-8.6.3 --no-terminal --only-dependencies
+    - run: stack build --compiler=ghc-8.8.4 --no-terminal -j1 Cabal wai-logger
+    - run: stack build --compiler=ghc-8.8.4 --no-terminal --only-dependencies
     - save_cache:
         key: 'dependencies-{{ checksum "stack.yaml" }}-{{ checksum "haskell-jp-blog.cabal" }}'
         paths:
@@ -30,7 +30,7 @@ jobs:
         keys:
         - 'executable-{{ checksum "src/site.hs" }}'
         - 'executable-'
-    - run: stack --compiler=ghc-8.6.3 --local-bin-path='.' --no-terminal install --pedantic
+    - run: stack --compiler=ghc-8.8.4 --local-bin-path='.' --no-terminal install --pedantic
     - save_cache:
         key: 'executable-{{ checksum "src/site.hs" }}'
         paths:
@@ -58,7 +58,7 @@ jobs:
 
   deploy:
     docker:
-    - image: haskell:8.6.3
+    - image: haskell:8.8.4
     steps:
     - checkout:
         path: ~/project

--- a/haskell-jp-blog.cabal
+++ b/haskell-jp-blog.cabal
@@ -15,6 +15,7 @@ executable site
                   , pandoc-types
                   , skylighting
                   , filepath
+                  , text
   ghc-options:      -threaded -Wall
   default-language: Haskell2010
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,5 @@
 flags: {}
 packages:
 - '.'
-extra-deps:
-- hakyll-4.12.5.1
-- lrucache-1.2.0.1
-resolver: lts-13.11
+extra-deps: []
+resolver: lts-16.25

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,24 +3,10 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages:
-- completed:
-    hackage: hakyll-4.12.5.1@sha256:d1948b265e6628bcb6875571212f9acefe23179c73ca4f87f417b290ff381ca6,8677
-    pantry-tree:
-      size: 7631
-      sha256: ac35d6b2a3b6d87517ff5184430a283c378330ec5da6f7dce26416568bf134ee
-  original:
-    hackage: hakyll-4.12.5.1
-- completed:
-    hackage: lrucache-1.2.0.1@sha256:18fc3d7052012c7ab3cd395160f34b53c5e1ec5379cc45185baf35b90ffadc2e,1254
-    pantry-tree:
-      size: 619
-      sha256: 61b2a39a11873f2d8a577e1f6b5e848d2f465ea7f6837ce15436796d3a20eda0
-  original:
-    hackage: lrucache-1.2.0.1
+packages: []
 snapshots:
 - completed:
-    size: 495801
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/13/11.yaml
-    sha256: 835062158db2b3ebb8b9525d9662a02ebf9783e8f6a08a64684cd5546f847152
-  original: lts-13.11
+    size: 533252
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/25.yaml
+    sha256: 147598b98bdd95ec0409bac125a4f1bff3cd4f8d73334d283d098f66a4bcc053
+  original: lts-16.25


### PR DESCRIPTION
<!--
**記事を寄稿していただける場合や、既存の記事を修正をされる場合は、予め https://github.com/haskell-jp/blog/blob/master/CONTRIBUTING.md#記事のライセンスについて をよく読み、同意してください**
-->

ずいぶん古いバージョンを利用していたので、現状の最新 LTS にしちゃおうかなと思います。
主な変更箇所は

- https://hackage.haskell.org/package/pandoc-types-1.20/docs/Text-Pandoc-Definition.html で利用している文字列型が `String` から `Text` に変わったことに関する修正
- https://hackage.haskell.org/package/hakyll-4.13.4.1/docs/Hakyll-Web-Template-List.html#v:sortRecentFirst が `MonadFail` をとるようになったことに関する修正
- CircleCI の GHC のバージョンを lts-16 のものにする（GHC 8.8.4）

特に最初のやつが影響でかくて。
というのも、`TextLang` という型を定義して `"あいueお"` を `[Japanese "あい", English "ue", Japanese "お"]` に変換して何かをしている。
この時の文字列が `String` なので困った。
`Text` に対してリスト処理っぽいことをする方法がぴんとこなかったので、とりあえず `Text` から `String` に変換して茶を濁しています。
何か他に良い方法が教えてください。 