### PR TITLE
GRCを紹介する記事を追加。

### DIFF
--- a/preprocessed-site/posts/about_us.md
+++ b/preprocessed-site/posts/about_us.md
@@ -46,3 +46,7 @@ Haskellは、関数型プログラミングの**強力な**サポートと、厳
     - 発言は[こちらのリポジトリー](https://github.com/haskell-jp/slack-log)の[doc/jsonディレクトリー](https://github.com/haskell-jp/slack-log/tree/master/doc/json)に**保存・公開**されます。あらかじめご容赦ください。
 - [定期的な勉強会やイベント](https://haskell-jp.connpass.com)の開催を通じた、ユーザー同士の交流の活性化。
     - Haskell-jp もくもく会: 趣味や仕事で書いてるプログラムの続きを書く、最近気になるあのライブラリを使ってみる、0から勉強してみる、など、Haskellに関する作業をもくもくとやったり、希望者でLTを行ったりするゆるい会です。[Haskellもくもく会](https://haskellmokumoku.connpass.com)を前身としています。
+
+# Haskell-jp Adminsこと日本Haskellユーザーグループ管理委員会について
+
+Haskell-jp Adminsについては[こちらの設立のお知らせ](about_admins.html)をご覧ください。

--- a/preprocessed-site/posts/grc.md
+++ b/preprocessed-site/posts/grc.md
@@ -3,7 +3,7 @@ title: 「相互を尊重したコミュニケーションのためのガイド�
 headingBackgroundImage: ../img/background.png
 headingDivClass: post-heading
 author: Haskell-jp Admins
-date: May 23, 2021
+date: May 30, 2021
 ...
 ---
 

--- a/preprocessed-site/posts/grc.md
+++ b/preprocessed-site/posts/grc.md
@@ -15,4 +15,4 @@ date: May 23, 2021
 
 このGRCは、今後[Haskell-jpのSlack Workspace](https://haskell.jp/signin-slack.html)や[Haskell-jpのGitHubにおけるOrganizationが管理するリポジトリー](https://github.com/haskell-jp/)、それからHaskell-jpとして開催するイベントなど、様々な場面で適用されます。参加されるみなさんはご理解の上、快適なコミュニティー活動をお楽しみください。
 
-それから、もちろん今秋開催予定のHaskell Day 2021においても、こちらのGRCを採用します。参加者、発表者、運営者の方々はご理解とご協力をよろしくお願いします。
+それから、もちろん今秋開催予定の[Haskell Day 2021](https://haskell.jp/haskell-day-2021/)においても、こちらのGRCを採用します。参加者、発表者、運営者の方々はご理解とご協力をよろしくお願いします。

--- a/preprocessed-site/posts/grc.md
+++ b/preprocessed-site/posts/grc.md
@@ -15,4 +15,4 @@ date: May 30, 2021
 
 このGRCは、今後[Haskell-jpのSlack Workspace](https://haskell.jp/signin-slack.html)や[Haskell-jpのGitHubにおけるOrganizationが管理するリポジトリー](https://github.com/haskell-jp/)、それからHaskell-jpとして開催するイベントなど、様々な場面で適用されます。参加されるみなさんはご理解の上、快適なコミュニティー活動をお楽しみください。
 
-それから、もちろん今秋開催予定の[Haskell Day 2021](https://haskell.jp/haskell-day-2021/)においても、こちらのGRCを採用します。参加者、発表者、運営者の方々はご理解とご協力をよろしくお願いします。
+加えて、もちろん今秋開催予定の[Haskell Day 2021](https://haskell.jp/haskell-day-2021/)においても、こちらのGRCを採用します。参加者、発表者、運営者の方々はご理解とご協力をよろしくお願いします。

--- a/preprocessed-site/posts/grc.md
+++ b/preprocessed-site/posts/grc.md
@@ -1,0 +1,18 @@
+---
+title: 「相互を尊重したコミュニケーションのためのガイドライン」制定のお知らせ
+headingBackgroundImage: ../img/background.png
+headingDivClass: post-heading
+author: Haskell-jp Admins
+date: May 23, 2021
+...
+---
+
+[先日のHaskell-jp Admins](about_admins.html)と同様に事務的な連絡で恐縮ですが、当ブログや[Haskell-jpのSlack Workspace](/signin-slack.html)、[GitHubのOrganization](https://haskell.jp/signin-slack.html)などにおけるコミュニケーションに適用される、[「相互を尊重したコミュニケーションのためのガイドライン」](https://github.com/haskell-jp/community/blob/master/GRC.md)を制定致しました。
+
+[Haskell-jp 相互を尊重したコミュニケーションのためのガイドライン](https://github.com/haskell-jp/community/blob/master/GRC.md)
+
+こちらは[Haskell FoundationにおけるGuidelines for Respectful Communication（「GRC」）](https://haskell.foundation/guidelines-for-respectful-communication/)を日本語に翻訳し、運用主体などをHaskell-jpにおける実態に合わせて書き換えたものです。いわゆる「行動規範<small>（Code Of Conduct。しばしば「COC」と略されます）</small>」と同じ役割を果たすものですが、行動規範と異なり、禁止事項よりも推奨事項を数多く挙げているのが特徴です。[このGRCを翻訳する前に、COCを提案した際の議論](https://github.com/haskell-jp/community/pull/29)においてGRCのこうした特徴が好まれ、採用に至りました。
+
+このGRCは、今後[Haskell-jpのSlack Workspace](https://haskell.jp/signin-slack.html)や[Haskell-jpのGitHubにおけるOrganizationが管理するリポジトリー](https://github.com/haskell-jp/)、それからHaskell-jpとして開催するイベントなど、様々な場面で適用されます。参加されるみなさんはご理解の上、快適なコミュニティー活動をお楽しみください。
+
+それから、もちろん今秋開催予定のHaskell Day 2021においても、こちらのGRCを採用します。参加者、発表者、運営者の方々はご理解とご協力をよろしくお願いします。

--- a/preprocessed-site/posts/grc.md
+++ b/preprocessed-site/posts/grc.md
@@ -11,7 +11,7 @@ date: May 23, 2021
 
 [Haskell-jp 相互を尊重したコミュニケーションのためのガイドライン](https://github.com/haskell-jp/community/blob/master/GRC.md)
 
-こちらは[Haskell FoundationにおけるGuidelines for Respectful Communication（「GRC」）](https://haskell.foundation/guidelines-for-respectful-communication/)を日本語に翻訳し、運用主体などをHaskell-jpにおける実態に合わせて書き換えたものです。いわゆる「行動規範<small>（Code Of Conduct。しばしば「COC」と略されます）</small>」と同じ役割を果たすものですが、行動規範と異なり、禁止事項よりも推奨事項を数多く挙げているのが特徴です。[このGRCを翻訳する前に、COCを提案した際の議論](https://github.com/haskell-jp/community/pull/29)においてGRCのこうした特徴が好まれ、採用に至りました。
+こちらは[Haskell FoundationにおけるGuidelines for Respectful Communication (GRC)](https://haskell.foundation/guidelines-for-respectful-communication/)を日本語に翻訳し、運用主体などをHaskell-jpにおける実態に合わせて書き換えたものです。いわゆる「行動規範<small>（Code Of Conduct。しばしば「COC」と略されます）</small>」と同じ役割を果たすものですが、行動規範と異なり、禁止事項よりも推奨事項を数多く挙げているのが特徴です。[このGRCを翻訳する前に、COCを提案した際の議論](https://github.com/haskell-jp/community/pull/29)においてGRCのこうした特徴が好まれ、採用に至りました。
 
 このGRCは、今後[Haskell-jpのSlack Workspace](https://haskell.jp/signin-slack.html)や[Haskell-jpのGitHubにおけるOrganizationが管理するリポジトリー](https://github.com/haskell-jp/)、それからHaskell-jpとして開催するイベントなど、様々な場面で適用されます。参加されるみなさんはご理解の上、快適なコミュニティー活動をお楽しみください。
 

--- a/preprocessed-site/posts/grc.md
+++ b/preprocessed-site/posts/grc.md
@@ -7,7 +7,7 @@ date: May 30, 2021
 ...
 ---
 
-[先日のHaskell-jp Admins](about_admins.html)と同様に事務的な連絡で恐縮ですが、当ブログや[Haskell-jpのSlack Workspace](/signin-slack.html)、[GitHubのOrganization](https://haskell.jp/signin-slack.html)などにおけるコミュニケーションに適用される、[「相互を尊重したコミュニケーションのためのガイドライン」](https://github.com/haskell-jp/community/blob/master/GRC.md)を制定致しました。
+[先日のHaskell-jp Admins](about_admins.html)と同様に事務的な連絡で恐縮ですが、当ブログや[Haskell-jpのSlack Workspace](https://haskell.jp/signin-slack.html)、[GitHubのOrganization](https://github.com/haskell-jp)などにおけるコミュニケーションに適用される、[「相互を尊重したコミュニケーションのためのガイドライン」](https://github.com/haskell-jp/community/blob/master/GRC.md)を制定致しました。
 
 [Haskell-jp 相互を尊重したコミュニケーションのためのガイドライン](https://github.com/haskell-jp/community/blob/master/GRC.md)
 

--- a/preprocessed-site/templates/default.html
+++ b/preprocessed-site/templates/default.html
@@ -90,6 +90,9 @@
                     <li>
                         <a href="https://www.reddit.com/r/haskell_jp/">Reddit</a>
                     </li>
+                    <li>
+                        <a href="https://github.com/haskell-jp/community/blob/master/GRC.md">GRC</a>
+                    </li>
                 </ul>
             </div>
             <!-- /.navbar-collapse -->


### PR DESCRIPTION
Haskell Day 2021にも触れているので @kakkun61 をレビュワーに追加させていただきます。

- [x] こちらに加え、画面上部のメニューにもGRCへのリンクを加えようか検討中です。  
  => スクショのとおりとりあえず加えてみました。まぁ、この数ならあとにHaskell Day 2021へのリンクを追加しても問題なさそうです。

# メニュー追加後のスクショ

## 大

![image](https://user-images.githubusercontent.com/227057/120096320-bbb52280-c165-11eb-8d2a-c66b4cd252f7.png)

## 中

![image](https://user-images.githubusercontent.com/227057/120096331-cc659880-c165-11eb-9a79-03921fd08100.png)

## 小

※ハンバーガーメニューをタップした後の状態

![image](https://user-images.githubusercontent.com/227057/120096342-d9828780-c165-11eb-8024-7bce6ceb6798.png)

# その他

あと、後回しにしていた件で、先日のHaskell-jp Adminsについての記事への導線を少し増やしました。