### PR TITLE
Slackの運用ルールについての説明を、現状に合わせて修正

### DIFF
--- a/preprocessed-site/posts/2017/01-first.md
+++ b/preprocessed-site/posts/2017/01-first.md
@@ -22,11 +22,11 @@ Haskell-jp立ち上げ前、有志による議論に使用していたSlackチ�
 
 現時点の運用ルールは、以下のとおりです。
 
-- **#general**では本Slackチーム自体に関する連絡に加え、**Haskellに関する質問を募集**します！
+- **#questions**や**#beginners**では**Haskellに関する質問を募集**します！
     - 質問に対する回答は、**スレッド機能を使って回答**しましょう。複数の質問を同時に投稿しやすくするための配慮です。
-- その他、いわゆる「[ネチケット](https://ja.wikipedia.org/wiki/ネチケット)（死語？）」を守り、参加者のみなさんが不快になるような行動は避けてください。
-- 追記: 発言を[SlackArchive](http://slackarchive.io/)というサービスを通して、**当Slackチームに所属しない人にも保存・公開**することにいたしました。あらかじめご容赦ください。
-    - 保存した発言は <https://haskell-jp.slackarchive.io/> で閲覧できます。
+- その他、「[GRC](https://github.com/haskell-jp/community/blob/master/GRC.md)」を守り、参加者のみなさんが不快になるような行動は避けてください。
+- 追記: 発言を[slack-log](https://github.com/haskell-jp/slack-log/)というツールを通して、**当Slackチームに所属しない人にも保存・公開**することにいたしました。あらかじめご容赦ください。
+    - 保存した発言は <https://haskell.jp/slack-log/> で閲覧できます。
 
 # その2 Haskellもくもく会 -> Haskell-jpもくもく会！
 


### PR DESCRIPTION
<!--
**記事を寄稿していただける場合や、既存の記事を修正をされる場合は、予め https://github.com/haskell-jp/blog/blob/master/CONTRIBUTING.md#記事のライセンスについて をよく読み、同意してください**
-->

Preview: https://933-86001049-gh.circle-artifacts.com/0/generated-site/posts/2017/01-first.html

https://github.com/haskell-jp/haskell-jp.github.io/pull/46 と同様に、slack-logについて明記するよう修正しました。またSlack Archiveはもう機能していないのでリンク毎削除しました。

そのほか、現在の運用状況に合わせて説明を改めました。