### PR TITLE
Update deploy key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
         path: ~/project
     - add-ssh-keys:
         fingerprints:
-          - "ce:26:f9:6a:ac:98:43:91:5c:c8:77:ef:11:13:d3:fc"
+          - "9f:97:4e:99:72:c0:62:1d:db:9e:8e:ce:62:3f:0a:52"
     - run: apt update
     - run: apt install -y make ssh-client
     - attach_workspace:


### PR DESCRIPTION
Fix https://github.com/haskell-jp/blog/issues/221

どういう原因か分かりませんが、デプロイの際使用するSSHの鍵がread onlyになってました。
新しい鍵を作り、そのfingerprintで置き換えることで対応できたはずです。
なお、新しい鍵は @haskell-jp-bot のUser keyとして作成しました。
[こちらのドキュメント](https://circleci.com/docs/github-integration/#deploy-keys-and-user-keys)における、

> To achieve fine-grained access to more than one repository, consider creating what GitHub calls a machine user. Give this user exactly the permissions your build requires, and then associate its user key with your project on CircleCI.

というアドバイスに従ったためです。私の権限ではなく @haskell-jp-bot の権限で利用できる範囲に鍵の有効な範囲を絞っているわけですね。

<!--
**記事を寄稿していただける場合や、既存の記事を修正をされる場合は、予め https://github.com/haskell-jp/blog/blob/master/CONTRIBUTING.md#記事のライセンスについて をよく読み、同意してください**
-->
